### PR TITLE
Fixes for geodetic coordinate computation from IFC

### DIFF
--- a/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
+++ b/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
@@ -463,21 +463,17 @@ public class BIMtoOSMParser {
     private void transformToGeodetic(LatLon llBuildingOrigin, ArrayList<BIMObject3D> preparedBIMData) {
         if (llBuildingOrigin != null) {
             // get building rotation matrix
-            Vector3D projectNorth = getProjectNorth();
             Vector3D trueNorth = getTrueNorth();
             Matrix3D rotationMatrix = null;
-            if (projectNorth != null && trueNorth != null) {
-                double rotationAngle = trueNorth.angleBetween(projectNorth);
+            if (trueNorth != null) {
+                double rotationAngle = new Vector3D(0,1,0).angleBetween(trueNorth);
                 rotationMatrix = ParserMath.getRotationMatrixZ(rotationAngle);
             }
-
-            if (rotationMatrix == null) return;
-
             for (BIMObject3D object : preparedBIMData) {
                 ArrayList<LatLon> transformedCoordinates = new ArrayList<>();
                 for (Vector3D point : object.getCartesianGeometryCoordinates()) {
                     // rotate point
-                    rotationMatrix.transform(point);
+                    if(rotationMatrix != null) rotationMatrix.transform(point);
                     // transform point
                     LatLon llPoint = ParserGeoMath.cartesianToGeodetic(point, new Vector3D(0.0, 0.0, 0.0), llBuildingOrigin, lengthUnit);
                     transformedCoordinates.add(llPoint);

--- a/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
+++ b/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
@@ -517,6 +517,7 @@ public class BIMtoOSMParser {
                 refLon.size()>3 ? prepareDoubleString(refLon.get(3)) : Double.NaN
         );
         // TODO: determine site offset, if not zero, calculate WCS LatLon from site LatLon
+        // actually, site offset should be handled in engineering CS, not in geodetic CS (matrix in transformToGeodetic)
 
         return new LatLon(lat, lon);
     }

--- a/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
+++ b/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
@@ -462,7 +462,6 @@ public class BIMtoOSMParser {
      */
     private void transformToGeodetic(LatLon llBuildingOrigin, ArrayList<BIMObject3D> preparedBIMData) {
         if (llBuildingOrigin != null) {
-
             // get building rotation matrix
             Vector3D projectNorth = getProjectNorth();
             Vector3D trueNorth = getTrueNorth();
@@ -530,12 +529,15 @@ public class BIMtoOSMParser {
         double lat = ParserGeoMath.degreeMinutesSecondsToLatLon(
                 prepareDoubleString(refLat.get(0)),
                 prepareDoubleString(refLat.get(1)),
-                prepareDoubleString(refLat.get(2)));
+                prepareDoubleString(refLat.get(2)),
+                refLat.size()>3 ? prepareDoubleString(refLat.get(3)) : Double.NaN
+            );
         double lon = ParserGeoMath.degreeMinutesSecondsToLatLon(
                 prepareDoubleString(refLon.get(0)),
                 prepareDoubleString(refLon.get(1)),
-                prepareDoubleString(refLon.get(2)));
-
+                prepareDoubleString(refLon.get(2)),
+                refLon.size()>3 ? prepareDoubleString(refLon.get(3)) : Double.NaN
+        );
         // if offset, calculate building origin without offset
         if (ifcSiteOffset != null && ifcSiteOffset.getX() != 0.0 && ifcSiteOffset.getY() != 0.0) {
             return ParserGeoMath.cartesianToGeodetic(new Vector3D(0.0, 0.0, 0.0), ifcSiteOffset, new LatLon(lat, lon), lengthUnit);

--- a/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
+++ b/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/BIMtoOSMParser.java
@@ -491,24 +491,6 @@ public class BIMtoOSMParser {
      */
     @SuppressWarnings("unchecked")
     private LatLon getLatLonBuildingOrigin(EntityInstance ifcSite) {
-        Vector3D ifcSiteOffset = null;
-        if (ifcSite.getAttributeValueBNasEntityInstance("Representation") != null) {
-            // get the offset between IfcSite geodetic coordinates and building origin coordinate
-            // handle IfcSite offset if IfcBoundingBox representation
-            List<IfcRepresentation> repObjectIdentities = BIMtoOSMUtility.getIfcRepresentations(ifcSite);
-            if (repObjectIdentities == null) return null;
-
-            IfcRepresentation boxRepresentation =
-                    BIMtoOSMUtility.getIfcRepresentation(repObjectIdentities, RepresentationIdentifier.Box);
-            if (boxRepresentation != null) {
-                // get offset
-                EntityInstance bb = boxRepresentation.getEntity();
-                EntityInstance bbItem = bb.getAttributeValueBNasEntityInstanceList("Items").get(0);
-                EntityInstance cartesianCorner = bbItem.getAttributeValueBNasEntityInstance("Corner");
-                ifcSiteOffset = IfcGeometryExtractor.ifcCoordinatesToVector3D(cartesianCorner);
-            }
-        }
-
         // get RefLatitude and RefLongitude of IfcSite
         List<String> refLat;
         List<String> refLon;
@@ -534,10 +516,7 @@ public class BIMtoOSMParser {
                 prepareDoubleString(refLon.get(2)),
                 refLon.size()>3 ? prepareDoubleString(refLon.get(3)) : Double.NaN
         );
-        // if offset, calculate building origin without offset
-        if (ifcSiteOffset != null && ifcSiteOffset.getX() != 0.0 && ifcSiteOffset.getY() != 0.0) {
-            return ParserGeoMath.cartesianToGeodetic(new Vector3D(0.0, 0.0, 0.0), ifcSiteOffset, new LatLon(lat, lon), lengthUnit);
-        }
+        // TODO: determine site offset, if not zero, calculate WCS LatLon from site LatLon
 
         return new LatLon(lat, lon);
     }

--- a/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/math/ParserGeoMath.java
+++ b/src/org/openstreetmap/josm/plugins/indoorhelper/io/parser/math/ParserGeoMath.java
@@ -54,8 +54,8 @@ public class ParserGeoMath {
         return new LatLon(Math.toDegrees(pointLat), Math.toDegrees(pointLon));
     }
 
-    public static double degreeMinutesSecondsToLatLon(double degrees, double minutes, double seconds) {
-        return degrees + (minutes / 60.0) + (seconds / 3600.0);
+    public static double degreeMinutesSecondsToLatLon(double degrees, double minutes, double seconds, double v) {
+        return degrees + (minutes / 60.0) + (seconds / 3600.0) + (Double.isNaN(v) ? 0 : v/3600000000.);
     }
 
     /**


### PR DESCRIPTION
The following points are fixed with these commits. Note: think project coordinate system (WCS) instead of building CS.

* Latitude and longitude may have an optional component below seconds.
* True north might be null if the Cartesian engineering CS y-axis points towards north.
* True north was calculated as an angle counter-clockwise from the x-axis, but rotation must be relative to y-axis.
* WCS rotation is not relevant, as true north is relative to WCS.
* Site's box offset is not relevant for the geodetic coordinates. It is correctly considered when resolving absolute coordinates.

These points are open:

* Site (reference for lat/long) may be offset and rotated relative to the WCS and the inverse of this transformation has to be applied to the resolved (absolute, WCS) coordinates before converting to geodetic coordinates (see TODO in code).
* IFC 4 allows for proper geolocation with projected CRS.


This has been tested with the [KIT Smiley west building](https://www.ifcwiki.org/index.php?title=KIT_IFC_Examples#IFC_4).

<image src="https://user-images.githubusercontent.com/356986/230797220-9ba365f9-af96-4633-8e9f-039ad2c0e2b7.png" width="300px" />
